### PR TITLE
Add `--duration` parameter to allow specifying the session duration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ Or alternately save them to your AWS credentials file to enable faster access fr
 
 By default, the credentials only last for 1 hour, but you can [edit that restriction on AWS and set a max of 12h session duration](https://aws.amazon.com/es/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/).
 
+After enabling access for more than one hour, you can specify the session duration in minutes using the ``--duration`` parameter:
+```sh
+> python src/onelogin/aws-assume-role/aws-assume-role.py --duration 160
+```
+
 You can also make it regenerate and update the credentials file by using the `--loop` option to specify the number of iterations, and --time to specify the minutes between iterations.
 
 For more info execute:

--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -45,6 +45,9 @@ def get_options():
                       help="Save Temporal AWS credentials using that profile name")
     parser.add_option("-f", "--file", dest="file", type="string",
                       help="Set a custom path to save the AWS credentials. (if not used, default AWS path is used)")
+    parser.add_option("-o", "--duration", dest="duration", type="int", default=60,
+                      help="Temporal credentials session duration, in minutes. Note that specifying a value larger "
+                           "than the maximum allowed CLI/API session duration for the AWS role will fail.")
 
     parser.add_option("-u", "--onelogin-username", dest="username", type="string",
                       help="OneLogin username (email address)")
@@ -309,7 +312,7 @@ def main():
             RoleArn=role_arn,
             PrincipalArn=principal_arn,
             SAMLAssertion=saml_response,
-            DurationSeconds=3600
+            DurationSeconds=options.duration * 60
         )
 
         access_key_id = aws_session_token['Credentials']['AccessKeyId']


### PR DESCRIPTION
In the readme we mention that AWS allows requesting sessions longer
than 1h for role assumption, but the session duration was hardcoded
to 1h, not allowing to take advantage of the feature.